### PR TITLE
Fix error: can't copy 'README': doesn't exist or not a regular file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup  (name        = 'sslstrip',
         packages  = ["sslstrip"],
         package_dir = {'sslstrip' : 'sslstrip/'},
         scripts = ['sslstrip/sslstrip'],
-        data_files = [('share/sslstrip', ['README', 'COPYING', 'lock.ico'])],
+        data_files = [('share/sslstrip', ['README.md', 'COPYING', 'lock.ico'])],
        )
 
 print "Cleaning up..."


### PR DESCRIPTION
Since README was modified in commit [74ba7c7](https://github.com/byt3bl33d3r/sslstrip2/commit/74ba7c758eb63a98ba71ae7123bcd3e0a8dd0602)  it doesn't install properly through setup.py

Without the fix:

> running install
> running build
> running build_py
> running build_scripts
> copying and adjusting sslstrip/sslstrip -> build/scripts-2.7
> running install_lib
> running install_scripts
> copying build/scripts-2.7/sslstrip -> /usr/local/bin
> changing mode of /usr/local/bin/sslstrip to 755
> running install_data
> error: can't copy 'README': doesn't exist or not a regular file

With the fix:

> running install
> running build
> running build_py
> running build_scripts
> copying and adjusting sslstrip/sslstrip -> build/scripts-2.7
> running install_lib
> running install_scripts
> copying build/scripts-2.7/sslstrip -> /usr/local/bin
> changing mode of /usr/local/bin/sslstrip to 755
> running install_data
> copying README.md -> /usr/local/share/sslstrip
> running install_egg_info
> Removing /usr/local/lib/python2.7/dist-packages/sslstrip-0.9.egg-info
> Writing /usr/local/lib/python2.7/dist-packages/sslstrip-0.9.egg-info
> Cleaning up...
